### PR TITLE
Loosen up the requirements for the future library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyrad >= 1.2
-future==0.16.0
+future

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='Django authentication backend for RADIUS',
     version=VERSION,
     license='BSD',
-    url='http://robgolding63.github.com/django-radius/',
+    url='http://robgolding.github.com/django-radius/',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
@@ -19,5 +19,5 @@ setup(
     ],
     zip_safe=False,
     packages=find_packages(),
-    install_requires=['pyrad >= 1.2,!=2.2', 'future==0.16.0'],
+    install_requires=['pyrad >= 1.2,!=2.2', 'future'],
 )


### PR DESCRIPTION
Pinning it to a specific version has started to cause problems.  Also,
fix the setup.py url for the homepage.

related https://github.com/robgolding/django-radius/issues/24